### PR TITLE
include and export `calc_bandreps` (supersedes and closes #37)

### DIFF
--- a/src/Crystalline.jl
+++ b/src/Crystalline.jl
@@ -157,6 +157,9 @@ export subduction_count
 include("bandrep.jl")
 export bandreps, matrix, classification, nontrivial_factors, basisdim
 
+include("calc_bandreps.jl")
+export calc_bandreps
+
 include("deprecations.jl")
 export get_littlegroups, get_lgirreps, get_pgirreps, WyckPos, kvec, wyck, kstar
 

--- a/test/calc_bandreps.jl
+++ b/test/calc_bandreps.jl
@@ -1,0 +1,142 @@
+using Test
+using Crystalline
+using Crystalline: dlm2struct
+
+@testset "calc_bandreps" begin
+
+# defines `is_exceptional_br` to check if a BR induced by a maximal Wyckoff position is an
+# "exceptional" BR, i.e., is in fact not an elementary BR (EBR)
+# include("ebr_exceptions.jl")
+# TODO: currently unused - figure out if we need it or not & keep/delete accordingly
+
+# ---------------------------------------------------------------------------------------- #
+
+@testset "2D: `calc_bandreps` vs. (tabulated) `bandreps`" begin
+    # test that `bandreps` agrees with `calc_bandreps` in 2D (since the former is generated
+    # by the latter; basically check that the data behind the former is up-to-date)
+    for sgnum in 1:17
+        for timereversal in (false, true)
+            @test calc_bandreps(sgnum, Val(2); timereversal, allpaths = false) ==
+                  bandreps(sgnum, 2; timereversal, allpaths = false)
+        end
+    end
+end
+
+@testset "3D: every reference EBR must have a match in a calculated BR" begin
+    debug = false
+    error_counts = Dict{String, Int}()
+    for sgnum in 1:230
+        had_sg_error = false
+        for timereversal in (false, true)
+            had_tr_error = false
+
+            brsᶜ = calc_bandreps(sgnum, Val(3); timereversal, allpaths = false)
+            brsʳ = bandreps(sgnum, 3; timereversal, allpaths = false)
+                      
+            # find a permutation of the irreps in `brsʳ` that matches `brsᶜ`'s sorting, s.t.
+            # `brsʳ.irlabs[irʳ²ᶜ_perm] == brsᶜ.irlabs`
+            irʳ²ᶜ_perm = [something(findfirst(==(irᶜ), brsʳ.irlabs)) for irᶜ in brsᶜ.irlabs]
+            append!(irʳ²ᶜ_perm, length(brsᶜ.irlabs)+1) # append occupation number
+
+            seen_wp = Dict{String, Bool}()
+            for brʳ in brsʳ
+                wpʳ = brʳ.wyckpos
+                idx = findfirst(brᶜ -> brᶜ.wyckpos == wpʳ && brᶜ.label == brʳ.label, brsᶜ)
+                haskey(seen_wp, wpʳ) || (seen_wp[wpʳ] = false)
+                if isnothing(idx)
+                    # this can sometimes happen spuriously because Bilbao (i.e. `brsʳ`)
+                    # lists the EBRs with unabbreviated Mulliken labels (e.g., A₁ rather 
+                    # than A or ¹E²E rather than E) even when it is possible to abbreviate
+                    # unambiguously (what `mulliken` does and what `brsᶜ` consequently
+                    # references); we account for that by doing a subsequent, slighly looser
+                    # check (below)
+                    idx = findfirst(brsᶜ) do brᶜ
+                        brʳ.wyckpos == brᶜ.wyckpos || return false
+                        labʳ = replace(brʳ.label, "↑G"=>"") 
+                        labᶜ = replace(brᶜ.label, "↑G"=>"")
+                        length(labᶜ) == 1 && only(labᶜ) == first(labʳ) && return true # e.g., A ~ A₁
+                        labʳ′ = replace(labʳ, "¹"=>"", "²"=>"")    # e.g., ¹E²E ~ E
+                        labʳ′ = replace(labʳ′, "EE" => "E", 
+                                               "EgEg" => "Eg", "EᵤEᵤ" => "Eᵤ",
+                                               "E₁E₁" => "E₁", "E₂E₂" => "E₂",
+                                               "E′′E′′" => "E′′", "E′E′" => "E′",
+                                               "E₁gE₁g" => "E₁g", "E₂gE₂g" => "E₂g",
+                                               "E₁ᵤE₁ᵤ" => "E₁ᵤ", "E₂ᵤE₂ᵤ" => "E₂ᵤ")
+                        labʳ′ == labᶜ && return true
+                    end
+                end
+                
+                @test idx !== nothing # test that an associated BR exists in brsʳ (it must)
+                idx = something(idx)
+
+                # there are a number of cases where it is impossible to test uniquely
+                # against Bilbao, because the assignment of irrep label to the site symmetry
+                # group is ambiguous (e.g., for site groups isomorphic to 222; but also for 
+                # mmm and mm2): in this case, the assignment of irreps depends on a choice
+                # of coordinate system, which we cannot be uniquely determined but
+                # so, for these cases, we cannot do a one-to-one comparison (but we can at
+                # least test whether the reference Bilbao vector occurs in the set of
+                # computed band representation vectors)
+                if brʳ.sitesym ∉ ("222", "mmm", "mm2", "-4m2")
+                    brᶜ = brsᶜ[idx]
+                    @test Vector(brᶜ) == brʳ[irʳ²ᶜ_perm]
+                    @test dim(brᶜ) == dim(brʳ)
+                elseif brʳ.sitesym == "-4m2"
+                    # this is a special case: in principle, it is possible to uniquely
+                    # assign the irrep labels, but we currently assign ones that are
+                    # different from those in Bilbao (see issue #59)
+                    # FIXME: remove this here and above once #59 is resolved
+                    @test brʳ[irʳ²ᶜ_perm] ∈ Vector.(brsᶜ)
+                    continue
+                else
+                    # simply test that the reference Bilbao _vector_ is in the set of
+                    # computed EBRs
+                    @test brʳ[irʳ²ᶜ_perm] ∈ Vector.(brsᶜ)
+                    continue
+                end
+                
+                if debug
+                    brᶜ = brsᶜ[idx]
+                    if !(Vector(brᶜ) == brʳ[irʳ²ᶜ_perm])
+                        had_sg_error || (print("sgnum = $sgnum\n"); had_sg_error = true)
+                        had_tr_error || (println("  timereversal = $timereversal"); had_tr_error = true)
+                        if !seen_wp[wpʳ]
+                            print("    site = $wpʳ (")
+                            printstyled("$(brʳ.sitesym)"; color=:yellow)
+                            println(")")
+                            seen_wp[wpʳ] = true
+                        end
+                        println("      $(replace(brʳ.label, "↑G"=>""))")
+                        brʳ′ = deepcopy(brʳ)
+                        brʳ′.irvec .= brʳ.irvec[irʳ²ᶜ_perm[1:end-1]]
+                        brʳ′.irlabs .= brʳ.irlabs[irʳ²ᶜ_perm[1:end-1]]
+                        println("        ref  = $brʳ′")
+                        println("        calc = $brᶜ")
+                        if haskey(error_counts, brʳ.sitesym)
+                            error_counts[brʳ.sitesym] += 1
+                        else
+                            error_counts[brʳ.sitesym] = 1
+                        end
+                    end
+                end
+            end
+        end
+        debug && had_sg_error && println()
+    end
+end
+
+@testset "Plane groups vs. parent space groups" begin
+    for (sgnum²ᴰ, sgnum³ᴰ) in enumerate(Crystalline.PLANE2SPACE_NUMS)
+        for timereversal in (false, true)
+            brs²ᴰ = bandreps(sgnum²ᴰ, 2; timereversal, allpaths = false)
+            brs³ᴰ = bandreps(sgnum³ᴰ, 3; timereversal, allpaths = false)
+
+            # dimensions
+            @test sort!(dim.(brs²ᴰ)) == sort!(dim.(brs³ᴰ))
+
+            # topological classification
+            @test classification(brs²ᴰ) == classification(brs³ᴰ)
+        end
+    end
+end
+end # @testset "calc_bandreps" begin

--- a/test/ebr_exceptions.jl
+++ b/test/ebr_exceptions.jl
@@ -1,0 +1,56 @@
+# general exceptions (Table 3 of https://doi.org/10.1103/PhysRevB.97.035139)
+const ebr_exceptions = Dict{Int, Tuple{Bool, String, Vector{String}}}(
+    # sgnum => (applies_with_tr, site group (Schoenflies notation), irreps (Mulliken notation))
+    ([163, 165, 167, 228, 230, 223, 211, 208, 210, 228, 188, 190, 192, 193] 
+            .=> Ref((false, "D₃"  #=312/321=#,    ["E"] #=Γ₃=#))) ...,
+      192    =>    ((false, "D₆"  #=622=#,        ["E₁", "E₂"] #=Γ₅, Γ₆=#)),
+    ([207, 211, 222, 124, 140] 
+            .=> Ref((false, "D₄"  #=422=#,        ["E"] #=Γ₅=#))) ...,
+    ([229, 226, 215, 217, 224, 131, 132, 139, 140, 223] 
+            .=> Ref((true, "D₂d" #=-42m/-4m2=#,  ["E"] #=Γ₅=#))) ...
+)
+
+# time-reversal exceptions (Table 2 of https://doi.org/10.1103/PhysRevB.97.035139)
+# always associated with site group S₄ (-4) and site irrep E (Γ₃Γ₄)
+const ebr_tr_exceptions = (84, 87, 135, 136, 112, 116, 120, 121, 126, 130, 133, 138, 142,
+                           218, 230, 222, 217, 219, 228)
+
+# ---------------------------------------------------------------------------------------- #
+
+function is_exceptional_br(sgnum::Integer, br::BandRep; timereversal::Bool=true)
+    # first check (Table 2): a composite physically real complex bandrep ("realified" rep)?
+    (timereversal && is_exceptional_tr_br(sgnum, br)) && return true      
+
+    # second check (Table 3)
+    haskey(ebr_exceptions, sgnum) || return false
+    except_applies_with_tr, except_sitesym, except_siteirlabs = ebr_exceptions[sgnum]
+
+    # if we have TR, table 3 entries only apply if `except_applies_with_tr = true`
+    timereversal && (except_applies_with_tr || return false)
+    
+    # check if site symmetry group matches
+    br_sitesym_iuc = br.sitesym == "32" ? "321" : br.sitesym
+    br_sitesym_schoenflies = Crystalline.PG_IUC2SCHOENFLIES[br_sitesym_iuc]
+    except_sitesym == br_sitesym_schoenflies || return false # didn't match
+
+    # check if site irrep matches
+    br_siteirlab = replace(br.label, "↑G"=>"")
+    br_siteirlab ∈ except_siteirlabs || return false # didn't match
+    
+    return true
+end
+
+function is_exceptional_tr_br(sgnum::Integer, br::BandRep)
+    sgnum ∈ ebr_tr_exceptions || return false
+
+    # check if site symmetry group is S₄
+    br_sitesym_iuc = br.sitesym == "32" ? "321" : br.sitesym
+    br_sitesym_schoenflies = Crystalline.PG_IUC2SCHOENFLIES[br_sitesym_iuc]
+    br_sitesym_schoenflies == "S₄" || return false
+
+    # check if site irrep is E
+    br_siteirlab = replace(br.label, "↑G"=>"")
+    br_siteirlab == "E" || return false
+
+    return true
+end

--- a/test/isomorphic_parent_pointgroup.jl
+++ b/test/isomorphic_parent_pointgroup.jl
@@ -1,0 +1,32 @@
+using Crystalline
+using Test
+
+@testset "Site symmetry groups & parent point group identification" begin
+    # here, we simply test that our identifications of the label associated with the site
+    #symmetry group's isomorphic point group are consistent with those made in the
+    # identification of the site symmetry group labels for band representations from the
+    # Bilbao Crystallographic Server
+    for sgnum in 1:MAX_SGNUM[3]
+        brs = bandreps(sgnum, 3)
+        sg  = spacegroup(sgnum, Val(3))
+        wps = wyckoffs(sgnum, Val(3))
+        sitegs = sitegroup.(Ref(sg), wps)
+        sitegs = findmaximal(sitegs)
+        for siteg in sitegs           
+            # "our" label
+            pg, _, _ = find_isomorphic_parent_pointgroup(siteg)
+            pglab = label(pg)
+            pglab = pglab ∈ ("312", "321")   ? "32"  : # normalize computed label (since
+                    pglab ∈ ("-31m", "-3m1") ? "-3m" : # Bilbao doesn't distinguish 
+                    pglab ∈ ("31m", "3m1")   ? "3m"  : # between e.g., 312 and 321)
+                    pglab
+
+            # Bilbao's label
+            idx = something(findfirst(br->br.wyckpos == label(siteg.wp), brs))
+            pglab_bilbao = brs[idx].sitesym
+
+            # compare
+            @test pglab == pglab_bilbao
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,9 +43,12 @@ using Crystalline, Test
     # additional k-vectors in Φ-Ω ("special" representation domain vectors)
     include("holosymmetric.jl")
 
-    # band representations
-    include("classification.jl")  # does topo classification agree w/ Adrian?
-    include("bandrep.jl")         # do k-vectors match (Bilbao's bandreps vs ISOTROPY)?
+    # band representations & site symmetry groups
+    include("classification.jl")  # => does topo classification agree w/ Adrian?
+    include("bandrep.jl")         # => do k-vectors match (Bilbao's bandreps vs ISOTROPY)?
+    include("calc_bandreps.jl")   # => tests of /src/calc_bandreps.jl
+    include("isomorphic_parent_pointgroup.jl") # => do we find the same "parent" point
+                                               #    groups as Bilbao?
 
     # magnetic space groups
     include("mspacegroup.jl")


### PR DESCRIPTION
The conflicts & git issues with #37 were a mess again, so I've factored out the relevants bits to this new branch. Hopefully, that should make the changes clearer again.

Should be good to go once if CI is green.